### PR TITLE
Use proto3 syntax for cloudstress agent results consumption

### DIFF
--- a/plugins/inputs/cloudstress_agent_consumer/cloudstress_agent_consumer.go
+++ b/plugins/inputs/cloudstress_agent_consumer/cloudstress_agent_consumer.go
@@ -168,9 +168,9 @@ func (c *CloudStressAgent) processMessages() {
 			for _, d := range updateMsg.Tags {
 				for i, v := range d.Values {
 					if i == 0 {
-						tags[*d.Key] = v
+						tags[d.Key] = v
 					} else {
-						tags[*d.Key] = tags[*d.Key] + ";" + v
+						tags[d.Key] = tags[d.Key] + ";" + v
 					}
 				}
 			}

--- a/proto/result.proto
+++ b/proto/result.proto
@@ -1,34 +1,34 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package result;
 
 message CpuLoad {
-  required uint64 utmost = 1;
-  required uint64 target = 2;
-  required uint64 actual = 3;
-  required uint64 system = 4;
-  required uint64 user   = 5;
-  required uint64 steal  = 6;
+  uint64 utmost = 1;
+  uint64 target = 2;
+  uint64 actual = 3;
+  uint64 system = 4;
+  uint64 user   = 5;
+  uint64 steal  = 6;
 }
 
 message IOStats {
-  required uint64 ops_target   = 1;
-  required uint64 ops_actual   = 2;
-  required uint64 bytes_target = 3;
-  required uint64 bytes_actual = 4;
-  required uint64 errors       = 5;
-  required uint64 latency      = 6;
-  optional uint64 latency_min  = 7;
-  optional uint64 latency_max  = 8;
+  uint64 ops_target   = 1;
+  uint64 ops_actual   = 2;
+  uint64 bytes_target = 3;
+  uint64 bytes_actual = 4;
+  uint64 errors       = 5;
+  uint64 latency      = 6;
+  uint64 latency_min  = 7;
+  uint64 latency_max  = 8;
 }
 
 message IOLoad {
-  required IOStats Read = 1;
-  required IOStats Write = 2;
+  IOStats Read = 1;
+  IOStats Write = 2;
 }
 
 message Multimap {
-  required string key    = 1;
+  string key    = 1;
   repeated string values = 2;
 }
 
@@ -39,13 +39,13 @@ message Update {
     MEMORY  = 2;
     NETWORK = 3;
   }
-  optional string uuid       = 1;    // provides identity of sender
-  required double timestamp  = 2;    // unix timestamp, e.g. seconds since Jan 1, 1970 UTC
-  required uint64 sequence   = 3;    // sequence number for this update type
-  required UpdateType type   = 4;    // type of update; indicates whether CpuLoad
+  string uuid       = 1;    // provides identity of sender
+  double timestamp  = 2;    // unix timestamp, e.g. seconds since Jan 1, 1970 UTC
+  uint64 sequence   = 3;    // sequence number for this update type
+  UpdateType type   = 4;    // type of update; indicates whether CpuLoad
                                      // or IOLoad message is present
-  optional CpuLoad cpu       = 5;    // only present for CPU results
-  optional IOLoad io         = 6;    // only present for BLOCK, MEMORY, or NETWORK results
+  CpuLoad cpu       = 5;    // only present for CPU results
+  IOLoad io         = 6;    // only present for BLOCK, MEMORY, or NETWORK results
 
   repeated Multimap     tags = 102;  // multitags for result data
 }


### PR DESCRIPTION
The CloudStress agent will be switching over to proto3 syntax.  This PR captures the necessary changes to support consumption of CS agent results.

The metrics agent can continue to use proto2 syntax for the time being.

The PR should not be merged until:
- proto3 version of CloudStress agent is ready (i.e., on S3).