### PR TITLE
Updated dependencies to protobuf 1.1.  Mostly this is for go get prot…

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -19,7 +19,7 @@ github.com/eapache/queue 44cc805cf13205b55f69e14bcb69867d1ae92f98
 github.com/eclipse/paho.mqtt.golang d4f545eb108a2d19f9b1a735689dbfb719bc21fb
 github.com/go-sql-driver/mysql 2e00b5cd70399450106cec6431c2e2ce3cae5034
 github.com/gobwas/glob bea32b9cd2d6f55753d94a28e959b13f0244797a
-github.com/golang/protobuf 130e6b02ab059e7b717a096f397c5b60111cae74
+github.com/golang/protobuf b4deda0973fb4c70b50d226b1af49f3da59f5265
 github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380
 github.com/gorilla/mux 392c28fe23e1c45ddba891b0320b3b5df220beea
 github.com/hailocab/go-hostpool e80d13ce29ede4452c43dea11e79b9bc8a15b478

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ package:
 # Get dependencies and use gdm to checkout changesets
 prepare:
 	go get github.com/sparrc/gdm
-	gdm restore
+	gdm vendor
 
 # Use the windows godeps file to prepare dependencies
 prepare-windows:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ windows: prepare-windows build-windows
 build:
 	cd proto && make
 	go install -ldflags \
-		"-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.branch=$(BRANCH)" ./...
+		"-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.branch=$(BRANCH)" ./cmd/...
 
 build-windows:
 	GOOS=windows GOARCH=amd64 go build -o telegraf.exe -ldflags \


### PR DESCRIPTION
…oc-gen-go usage but 1.1 can have perf improvements too in some cases.  New deps work with old protoc-gen-go so win win.